### PR TITLE
Wrap default favicons in a twig block

### DIFF
--- a/source/twig/layout/template.html.twig
+++ b/source/twig/layout/template.html.twig
@@ -13,11 +13,13 @@
 		<meta name="description" content="">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<link rel="icon" type="image/png" href="/favicon.png">
-		<link rel="apple-touch-icon-precomposed" href="/apple-touch-iphone.png">
-		<link rel="apple-touch-icon-precomposed" sizes="72x72" href="/apple-touch-ipad.png">
-		<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/apple-touch-iphone4.png">
-		<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-ipad-retina.png">
+		{% block favicons %}
+			<link rel="icon" type="image/png" href="/favicon.png">
+			<link rel="apple-touch-icon-precomposed" href="/apple-touch-iphone.png">
+			<link rel="apple-touch-icon-precomposed" sizes="72x72" href="/apple-touch-ipad.png">
+			<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/apple-touch-iphone4.png">
+			<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-ipad-retina.png">
+		{% endblock %}
 
 		{% block styles %}
 			<link rel="stylesheet" href="css/main.css">


### PR DESCRIPTION
### What has been done:
- Wrapped the template code around favicons in a twig block, allowing other applications to overwrite the favicon's template code.

### How to test
- Include this bundle in a Symfony project
- Create a twig template, extending the changed `layout/template.html.twig`
- Acknowledge you're able to overwrite the favicons block. 
